### PR TITLE
Handle empty Supabase responses and document dashboard startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ PWA de exemplo para o projeto **mobileTeste** usando Supabase.
 Os arquivos principais estão em `mobileTeste/` e incluem um dashboard simples para visualizar os dados da tabela `pedidos_local`.
 
 Para criar as tabelas necessárias no Supabase, utilize o script SQL em `mobileTeste/schema.sql`.
+
+## Como executar o dashboard
+
+1. Instale e inicie um servidor HTTP simples, por exemplo com o [http-server](https://www.npmjs.com/package/http-server):
+
+   ```bash
+   npx http-server mobileTeste -p 8080
+   ```
+
+2. Acesse o endereço [http://localhost:8080](http://localhost:8080) no navegador para ver o dashboard.

--- a/mobileTeste/dashboard.js
+++ b/mobileTeste/dashboard.js
@@ -10,13 +10,24 @@ async function loadPedidos() {
     .select('*')
     .limit(50);
 
-  if (error) {
+  const tbody = document.querySelector('#pedidosTable tbody');
+  tbody.innerHTML = '';
+
+  if (error || !Array.isArray(data)) {
     console.error('Erro ao carregar pedidos:', error);
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td colspan="7">Erro ao carregar pedidos</td>`;
+    tbody.appendChild(tr);
     return;
   }
 
-  const tbody = document.querySelector('#pedidosTable tbody');
-  tbody.innerHTML = '';
+  if (data.length === 0) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td colspan="7">Nenhum pedido encontrado</td>`;
+    tbody.appendChild(tr);
+    return;
+  }
+
   data.forEach(ped => {
     const tr = document.createElement('tr');
     tr.innerHTML = `


### PR DESCRIPTION
## Summary
- show message when no data or loading error on dashboard
- document how to run the dashboard with a local http server

## Testing
- `node --check mobileTeste/dashboard.js`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af38f163808326a67b4dd941c0fc49