### PR TITLE
Add line and pie charts to dashboard

### DIFF
--- a/mobileTeste/dashboard.js
+++ b/mobileTeste/dashboard.js
@@ -41,6 +41,8 @@ async function loadPedidos() {
     `;
     tbody.appendChild(tr);
   });
+
+  renderCharts(data);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -49,3 +51,53 @@ document.addEventListener('DOMContentLoaded', () => {
     navigator.serviceWorker.register('sw.js');
   }
 });
+
+function renderCharts(pedidos) {
+  if (!Array.isArray(pedidos) || typeof Chart === 'undefined') {
+    return;
+  }
+
+  // Line chart: total value by date
+  const totalsByDate = {};
+  pedidos.forEach(p => {
+    const date = p.PDOC_DT_EMISSAO || 'Sem data';
+    const total = parseFloat(p.PDOC_VLR_TOTAL) || 0;
+    totalsByDate[date] = (totalsByDate[date] || 0) + total;
+  });
+  const lineLabels = Object.keys(totalsByDate).sort();
+  const lineData = lineLabels.map(l => totalsByDate[l]);
+  const lineCtx = document.getElementById('lineChart').getContext('2d');
+  new Chart(lineCtx, {
+    type: 'line',
+    data: {
+      labels: lineLabels,
+      datasets: [{
+        label: 'Total por Data',
+        data: lineData,
+        borderColor: 'blue',
+        fill: false
+      }]
+    }
+  });
+
+  // Pie chart: total value by company
+  const totalsByEmpresa = {};
+  pedidos.forEach(p => {
+    const empresa = p.CEMP_PK || 'Sem empresa';
+    const total = parseFloat(p.PDOC_VLR_TOTAL) || 0;
+    totalsByEmpresa[empresa] = (totalsByEmpresa[empresa] || 0) + total;
+  });
+  const pieLabels = Object.keys(totalsByEmpresa);
+  const pieData = pieLabels.map(l => totalsByEmpresa[l]);
+  const pieCtx = document.getElementById('pieChart').getContext('2d');
+  new Chart(pieCtx, {
+    type: 'pie',
+    data: {
+      labels: pieLabels,
+      datasets: [{
+        data: pieData,
+        backgroundColor: pieLabels.map((_, i) => `hsl(${(i * 360) / pieLabels.length}, 70%, 60%)`)
+      }]
+    }
+  });
+}

--- a/mobileTeste/index.html
+++ b/mobileTeste/index.html
@@ -23,6 +23,9 @@
     </thead>
     <tbody></tbody>
   </table>
+  <canvas id="lineChart"></canvas>
+  <canvas id="pieChart"></canvas>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="dashboard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display totals by date in a line chart and totals by company in a pie chart
- include Chart.js and canvas elements for new charts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af3ad1f61c83268c370909c6db0537