### PR TITLE
Fix Chart.js CDN path to display graphs

### DIFF
--- a/mobileTeste/index.html
+++ b/mobileTeste/index.html
@@ -25,7 +25,7 @@
   </table>
   <canvas id="lineChart"></canvas>
   <canvas id="pieChart"></canvas>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script type="module" src="dashboard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Chart.js UMD build so charts render correctly

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af3c1625088326a547f2e6a92c5e5a